### PR TITLE
API-648 rewrite node example to use http Authorization Header

### DIFF
--- a/lib/fidor_starter_kits/version.rb
+++ b/lib/fidor_starter_kits/version.rb
@@ -1,3 +1,3 @@
 module FidorStarterKits
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end


### PR DESCRIPTION
This is a revision of the node examples to use the HTTP Authorization Header to transport the access_token instead of using url parameter.

After merge: release (version is bumped to 0.3.4).
