### PR TITLE
API-802 - header & http-basic

### DIFF
--- a/starter_kits/node_tx/example.js
+++ b/starter_kits/node_tx/example.js
@@ -77,7 +77,8 @@ function retrieve_access_token_from_code( code, target_endpoint, cb ) {
     method: "POST",
     path  : oauth_url.path+"/token",
     port  : oauth_url.port,
-    host  : oauth_url.hostname
+    host  : oauth_url.hostname,
+    auth  : fidor_config.client_id+":"+fidor_config.client_secret
   }
 
   // ... what to send
@@ -85,7 +86,7 @@ function retrieve_access_token_from_code( code, target_endpoint, cb ) {
   var postData = {
     code          : code,
     client_id     : fidor_config.client_id,
-    client_secret : fidor_config.client_secret,
+    // client_secret : fidor_config.client_secret, // deprecated, please use basic auth, see. postOptions, above
     redirect_uri  : encodeURIComponent(redirect_uri),
     grant_type    : "authorization_code"
   }
@@ -205,7 +206,8 @@ function render (endpoint, req, res) {
       port: api_endpoint.port,
       method: "GET",
       headers: {
-        "Authorization": "Bearer "+access_token
+        "Authorization": "Bearer "+access_token,
+        "Accept": "application/vnd.fidor.de; version=1,text/json"
       }
     }
 

--- a/starter_kits/ruby_oauth_plain/example.rb
+++ b/starter_kits/ruby_oauth_plain/example.rb
@@ -24,7 +24,7 @@ get '/' do
                   #client_secret: @client_secret,
                   grant_type: 'authorization_code' }
   auth = {:username => @client_id, :password => @client_secret}
-  resp = HTTParty.post(token_url, body: post_params, basic_auth: {} )
+  resp = HTTParty.post(token_url, body: post_params, basic_auth: auth )
 
   # GET current user setting the access-token in the request header
   user = HTTParty.get( "#{@fidor_api_url}/users/current",

--- a/starter_kits/ruby_oauth_plain/example.rb
+++ b/starter_kits/ruby_oauth_plain/example.rb
@@ -21,13 +21,15 @@ get '/' do
   post_params = { client_id: @client_id,
                   redirect_uri: CGI::escape(@app_url),
                   code: code,
-                  client_secret: @client_secret,
+                  #client_secret: @client_secret,
                   grant_type: 'authorization_code' }
-  resp = HTTParty.post(token_url, body: post_params )
+  auth = {:username => @client_id, :password => @client_secret}
+  resp = HTTParty.post(token_url, body: post_params, basic_auth: {} )
 
   # GET current user setting the access-token in the request header
   user = HTTParty.get( "#{@fidor_api_url}/users/current",
-                       headers: { 'Authorization' => "Bearer #{resp['access_token']}"} )
+                       headers: { 'Authorization' => "Bearer #{resp['access_token']}",
+                                  'Accept'        => "application/vnd.fidor.de; version=1,text/json"} )
 
   "<h2>Hello #{user['email']}</h2>
    <i>May i present the access token response:</i>


### PR DESCRIPTION
update node and go examples to reflect:
- usage of vnd.application header of api (?)
- http basic authentification for oauth instead of parameter based
